### PR TITLE
Fix some issues reported by lintian

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,11 +1,15 @@
 spin (6.5.2+dfsg-1) UNRELEASED; urgency=medium
 
+  [ Tom Lee ]
   * New upstream release 6.5.2
   * Bump Standards-Version to 4.5.0
   * debian-compat 12
   * Fix various build and lintian issues
   * Exclude binaries under Bin/ in upstream tarball during repack
   * Also exclude book errata under Docs/ until copyright can be determined
+
+  [ Debian Janitor ]
+  * Use secure URI in Homepage field.
 
  -- Tom Lee <debian@tomlee.co>  Sat, 25 Apr 2020 20:50:11 -0700
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -10,6 +10,8 @@ spin (6.5.2+dfsg-1) UNRELEASED; urgency=medium
 
   [ Debian Janitor ]
   * Use secure URI in Homepage field.
+  * Set upstream metadata fields: Bug-Database, Bug-Submit, Repository,
+    Repository-Browse.
 
  -- Tom Lee <debian@tomlee.co>  Sat, 25 Apr 2020 20:50:11 -0700
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -12,6 +12,7 @@ spin (6.5.2+dfsg-1) UNRELEASED; urgency=medium
   * Use secure URI in Homepage field.
   * Set upstream metadata fields: Bug-Database, Bug-Submit, Repository,
     Repository-Browse.
+  * Use canonical URL in Vcs-Git.
 
  -- Tom Lee <debian@tomlee.co>  Sat, 25 Apr 2020 20:50:11 -0700
 

--- a/debian/control
+++ b/debian/control
@@ -7,7 +7,7 @@ Build-Depends: debhelper-compat (= 12), bison
 Standards-Version: 4.5.0
 Rules-Requires-Root: no
 Homepage: https://spinroot.com
-Vcs-Git: https://github.com/thomaslee/spin-debian
+Vcs-Git: https://github.com/thomaslee/spin-debian.git
 Vcs-Browser: https://github.com/thomaslee/spin-debian
 
 Package: spin

--- a/debian/control
+++ b/debian/control
@@ -6,7 +6,7 @@ Uploaders: tony mancill <tmancill@debian.org>
 Build-Depends: debhelper-compat (= 12), bison
 Standards-Version: 4.5.0
 Rules-Requires-Root: no
-Homepage: http://spinroot.com
+Homepage: https://spinroot.com
 Vcs-Git: https://github.com/thomaslee/spin-debian
 Vcs-Browser: https://github.com/thomaslee/spin-debian
 

--- a/debian/upstream/metadata
+++ b/debian/upstream/metadata
@@ -1,0 +1,4 @@
+Bug-Database: https://github.com/nimble-code/Spin/issues
+Bug-Submit: https://github.com/nimble-code/Spin/issues/new
+Repository: https://github.com/nimble-code/Spin.git
+Repository-Browse: https://github.com/nimble-code/Spin


### PR DESCRIPTION
Fix some issues reported by lintian
* Use secure URI in Homepage field. ([homepage-field-uses-insecure-uri](https://lintian.debian.org/tags/homepage-field-uses-insecure-uri.html))
* Set upstream metadata fields: Bug-Database, Bug-Submit, Repository, Repository-Browse. ([upstream-metadata-file-is-missing](https://lintian.debian.org/tags/upstream-metadata-file-is-missing.html), [upstream-metadata-missing-bug-tracking](https://lintian.debian.org/tags/upstream-metadata-missing-bug-tracking.html), [upstream-metadata-missing-repository](https://lintian.debian.org/tags/upstream-metadata-missing-repository.html))
* Use canonical URL in Vcs-Git. ([vcs-field-not-canonical](https://lintian.debian.org/tags/vcs-field-not-canonical.html))


This merge proposal was created automatically by the [Janitor bot](https://janitor.debian.net/lintian-fixes).

You can follow up to this merge proposal as you normally would.

Build and test logs for this branch can be found at
https://janitor.debian.net/lintian-fixes/pkg/spin/5413c697-5dbf-46cd-874b-f0218db9b07c.


## Debdiff

These changes affect the binary packages:


File lists identical (after any substitutions)
### Control files of package spin: lines which differ (wdiff format)
* Homepage: [-http&#8203;://spinroot.com-] {+https&#8203;://spinroot.com+}

No differences were encountered between the control files of package \*\*spin-dbgsym\*\*


You can also view the [diffoscope diff](https://janitor.debian.net/api/run/5413c697-5dbf-46cd-874b-f0218db9b07c/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/5413c697-5dbf-46cd-874b-f0218db9b07c/diffoscope)).
