### PR TITLE
Remove unnecessary constraints

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,11 +1,17 @@
 spin (6.5.2+dfsg-1) UNRELEASED; urgency=medium
 
+  [ Tom Lee ]
   * New upstream release 6.5.2
   * Bump Standards-Version to 4.5.0
   * debian-compat 12
   * Fix various build and lintian issues
   * Exclude binaries under Bin/ in upstream tarball during repack
   * Also exclude book errata under Docs/ until copyright can be determined
+
+  [ Debian Janitor ]
+  * Remove constraints unnecessary since stretch:
+    + spin: Drop versioned constraint on staden in Replaces.
+    + spin: Drop versioned constraint on staden in Breaks.
 
  -- Tom Lee <debian@tomlee.co>  Sat, 25 Apr 2020 20:50:11 -0700
 

--- a/debian/control
+++ b/debian/control
@@ -13,8 +13,6 @@ Vcs-Browser: https://github.com/thomaslee/spin-debian
 Package: spin
 Architecture: any
 Depends: ${shlibs:Depends}, ${misc:Depends}
-Breaks: staden (<< 2.0.0+b11)
-Replaces: staden (<< 2.0.0+b11)
 Description: formal software verification tool
  Spin is a popular open-source software verification tool, used by thousands
  of people worldwide. The tool can be used for the formal verification of


### PR DESCRIPTION

Remove unnecessary constraints.


This merge proposal was created automatically by the [Janitor bot](https://janitor.debian.net/scrub-obsolete).
For more information, including instructions on how to disable
these merge proposals, see https://janitor.debian.net/scrub-obsolete.

You can follow up to this merge proposal as you normally would.

The bot will automatically update the merge proposal to resolve merge conflicts
or close the merge proposal when all changes are applied through other means
(e.g. cherry-picks). Updates may take several hours to propagate.

Build and test logs for this branch can be found at
https://janitor.debian.net/scrub-obsolete/pkg/spin/ec400b02-51be-4435-a5ae-de835f29c4fc.



## Debdiff

These changes affect the binary packages:


[The following lists of changes regard files as different if they have
different names, permissions or owners.]
### Files in second set of .debs but not in first
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/ec/16ccbfcb7adf4467966d3069952093444b3c72.debug
### Files in first set of .debs but not in second
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/9d/7efedd827b7d480602966977b0bc5f3898d8ea.debug
### Control files of package spin: lines which differ (wdiff format)
* [-Breaks: staden (<< 2.0.0+b11)-]
* [-Replaces: staden (<< 2.0.0+b11)-]
### Control files of package spin-dbgsym: lines which differ (wdiff format)
* Build-Ids: [-9d7efedd827b7d480602966977b0bc5f3898d8ea-] {+ec16ccbfcb7adf4467966d3069952093444b3c72+}


You can also view the [diffoscope diff](https://janitor.debian.net/api/run/ec400b02-51be-4435-a5ae-de835f29c4fc/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/ec400b02-51be-4435-a5ae-de835f29c4fc/diffoscope)).
