### PR TITLE
Fix some issues reported by lintian

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -14,6 +14,7 @@ spin (6.5.2+dfsg-1) UNRELEASED; urgency=medium
     + spin: Drop versioned constraint on staden in Breaks.
   * Update lintian override info format in d/spin.lintian-overrides on line 1.
   * Bump debhelper from old 12 to 13.
+  * Set upstream metadata fields: Bug-Database, Bug-Submit, Repository-Browse.
 
  -- Tom Lee <debian@tomlee.co>  Sat, 25 Apr 2020 20:50:11 -0700
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -12,6 +12,7 @@ spin (6.5.2+dfsg-1) UNRELEASED; urgency=medium
   * Remove constraints unnecessary since stretch:
     + spin: Drop versioned constraint on staden in Replaces.
     + spin: Drop versioned constraint on staden in Breaks.
+  * Update lintian override info format in d/spin.lintian-overrides on line 1.
 
  -- Tom Lee <debian@tomlee.co>  Sat, 25 Apr 2020 20:50:11 -0700
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -13,6 +13,7 @@ spin (6.5.2+dfsg-1) UNRELEASED; urgency=medium
     + spin: Drop versioned constraint on staden in Replaces.
     + spin: Drop versioned constraint on staden in Breaks.
   * Update lintian override info format in d/spin.lintian-overrides on line 1.
+  * Bump debhelper from old 12 to 13.
 
  -- Tom Lee <debian@tomlee.co>  Sat, 25 Apr 2020 20:50:11 -0700
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -16,6 +16,7 @@ spin (6.5.2+dfsg-1) UNRELEASED; urgency=medium
   * Bump debhelper from old 12 to 13.
   * Set upstream metadata fields: Bug-Database, Bug-Submit, Repository-Browse.
   * Use canonical URL in Vcs-Git.
+  * Update standards version to 4.6.2, no changes needed.
 
  -- Tom Lee <debian@tomlee.co>  Sat, 25 Apr 2020 20:50:11 -0700
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -15,6 +15,7 @@ spin (6.5.2+dfsg-1) UNRELEASED; urgency=medium
   * Update lintian override info format in d/spin.lintian-overrides on line 1.
   * Bump debhelper from old 12 to 13.
   * Set upstream metadata fields: Bug-Database, Bug-Submit, Repository-Browse.
+  * Use canonical URL in Vcs-Git.
 
  -- Tom Lee <debian@tomlee.co>  Sat, 25 Apr 2020 20:50:11 -0700
 

--- a/debian/control
+++ b/debian/control
@@ -4,7 +4,7 @@ Priority: optional
 Maintainer: Tom Lee <debian@tomlee.co>
 Uploaders: tony mancill <tmancill@debian.org>
 Build-Depends: debhelper-compat (= 13), bison
-Standards-Version: 4.5.0
+Standards-Version: 4.6.2
 Rules-Requires-Root: no
 Homepage: http://spinroot.com
 Vcs-Git: https://github.com/thomaslee/spin-debian.git

--- a/debian/control
+++ b/debian/control
@@ -3,7 +3,7 @@ Section: devel
 Priority: optional
 Maintainer: Tom Lee <debian@tomlee.co>
 Uploaders: tony mancill <tmancill@debian.org>
-Build-Depends: debhelper-compat (= 12), bison
+Build-Depends: debhelper-compat (= 13), bison
 Standards-Version: 4.5.0
 Rules-Requires-Root: no
 Homepage: http://spinroot.com

--- a/debian/control
+++ b/debian/control
@@ -7,7 +7,7 @@ Build-Depends: debhelper-compat (= 13), bison
 Standards-Version: 4.5.0
 Rules-Requires-Root: no
 Homepage: http://spinroot.com
-Vcs-Git: https://github.com/thomaslee/spin-debian
+Vcs-Git: https://github.com/thomaslee/spin-debian.git
 Vcs-Browser: https://github.com/thomaslee/spin-debian
 
 Package: spin

--- a/debian/spin.lintian-overrides
+++ b/debian/spin.lintian-overrides
@@ -1,1 +1,1 @@
-spin: spelling-error-in-binary usr/bin/spin upto up to
+spin: spelling-error-in-binary upto up to [usr/bin/spin]

--- a/debian/upstream/metadata
+++ b/debian/upstream/metadata
@@ -1,0 +1,4 @@
+---
+Bug-Database: https://github.com/nimble-code/Spin/issues
+Bug-Submit: https://github.com/nimble-code/Spin/issues/new
+Repository-Browse: https://github.com/nimble-code/Spin


### PR DESCRIPTION
Fix some issues reported by lintian

* Update lintian override info format in d/spin.lintian-overrides on line 1. ([mismatched-override](https://lintian.debian.org/tags/mismatched-override))
* Bump debhelper from old 12 to 13. ([package-uses-old-debhelper-compat-version](https://lintian.debian.org/tags/package-uses-old-debhelper-compat-version))
* Set upstream metadata fields: Bug-Database, Bug-Submit, Repository-Browse. ([upstream-metadata-file-is-missing](https://lintian.debian.org/tags/upstream-metadata-file-is-missing), [upstream-metadata-missing-bug-tracking](https://lintian.debian.org/tags/upstream-metadata-missing-bug-tracking))
* Use canonical URL in Vcs-Git. ([vcs-field-not-canonical](https://lintian.debian.org/tags/vcs-field-not-canonical))
* Update standards version to 4.6.2, no changes needed. ([out-of-date-standards-version](https://lintian.debian.org/tags/out-of-date-standards-version))

## Debdiff

These changes affect the binary packages:

[The following lists of changes regard files as different if they have
different names, permissions or owners.]
### Files in second set of .debs but not in first
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/be/487aa0bb2ba6405fbb10e29f3a75c28fa387db.debug
### Files in first set of .debs but not in second
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/ff/c408ab364ac688e7ccd486297e6274c7d28ae3.debug

No differences were encountered between the control files of package \*\*spin\*\*
### Control files of package spin-dbgsym: lines which differ (wdiff format)
* Build-Ids: [-ffc408ab364ac688e7ccd486297e6274c7d28ae3-] {+be487aa0bb2ba6405fbb10e29f3a75c28fa387db+}

You can also view the [diffoscope diff](https://janitor.debian.net/api/run/6949322f-eb1b-49e2-b272-7af82213d798/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/6949322f-eb1b-49e2-b272-7af82213d798/diffoscope)).

This merge proposal was created by the [Janitor bot](https://janitor.debian.net/lintian-fixes), and it will automatically rebase or close this proposal as appropriate when the target branch changes. Any comments you leave here will be read by the Janitor's maintainers.

Build and test logs for this branch can be found at https://janitor.debian.net/lintian-fixes/pkg/spin/6949322f-eb1b-49e2-b272-7af82213d798.